### PR TITLE
date picker bug fix

### DIFF
--- a/staxing/assignment.py
+++ b/staxing/assignment.py
@@ -307,8 +307,9 @@ class Assignment(object):
         self.adjust_date_picker(driver, date_element, change)
         driver.find_element(
             By.XPATH,
-            '//div[contains(@class,"datepicker__day") and text()="%s"]' %
-            change.day
+            '//div[contains(@class,"datepicker__day") ' +
+            'and not(contains(@class,"disabled")) ' +
+            'and text()="%s"]' % change.day
         ).click()
 
     def assign_periods(self, driver, periods):


### PR DESCRIPTION
date picker was getting messed up at the end of the month.
For example when wanting to click October 30th September 30th would still be on the calendar at the top. The date-picker was trying to click September 30th because it came before October 30th so just added in a line to make sure it doesn't click disabled days.
